### PR TITLE
Added iPhone 6S (iPhone 8,1) 10.3.1  and iPhone 5S (iPhone 6,1) 10.3.2 Symbols (develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fat creds to stek on the r/w stuff, and originally xerub too.
 
 The offsets used are for iPhone 7 on iOS 10.3.1 and must be changed if that's not what you're using.
 
-Offsets for iPod 6G (iPod7,1) 10.3.3, iPhone 7 (iPhone9,1) 10.3.3 and iPhone 6S (iPhone8,1) 10.3.2 are also included, however you will have to be a big boy and switch them out yourself in the v0rtex.m file.
+Offsets for iPod 6G (iPod7,1) 10.3.3, iPhone 7 (iPhone9,1) 10.3.3, iPhone 6S (iPhone8,1) 10.3.2 and iPhone 6S (iPhone 8,1) 10.3.1 are also included, however you will have to be a big boy and switch them out yourself in the v0rtex.m file.
 
 To find your own offsets read [this guide](https://gist.github.com/uroboro/5b2b2b2aa1793132c4e91826ce844957).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fat creds to stek on the r/w stuff, and originally xerub too.
 
 The offsets used are for iPhone 7 on iOS 10.3.1 and must be changed if that's not what you're using.
 
-Offsets for iPod 6G (iPod7,1) 10.3.3, iPhone 7 (iPhone9,1) 10.3.3, iPhone 6S (iPhone8,1) 10.3.2 and iPhone 6S (iPhone 8,1) 10.3.1 are also included, however you will have to be a big boy and switch them out yourself in the v0rtex.m file.
+Offsets for iPod 6G (iPod7,1) 10.3.3, iPhone 7 (iPhone9,1) 10.3.3, iPhone 6S (iPhone8,1) 10.3.2, iPhone 6S (iPhone 8,1) 10.3.1 and iPhone 5S (iPhone 6,1) 10.3.2 are also included, however you will have to be a big boy and switch them out yourself in the v0rtex.m file.
 
 To find your own offsets read [this guide](https://gist.github.com/uroboro/5b2b2b2aa1793132c4e91826ce844957).
 

--- a/v0rtex-S/symbols.m
+++ b/v0rtex-S/symbols.m
@@ -103,6 +103,28 @@ BOOL init_symbols()
         OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075b40b0;
     }
     
+    // iPhone 5S (iPhone 6,1) 10.3.2
+    else if (strcmp(u.version, "Darwin Kernel Version 16.6.0: Mon Apr 17 17:33:35 PDT 2017; root:xnu-3789.60.24~24/RELEASE_ARM64_S5L8960X") == 0) {
+        OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+        OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+        OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+        OFFSET_REALHOST                             = 0xfffffff00752eba0;
+        OFFSET_BZERO                                = 0xfffffff007081f80;
+        OFFSET_BCOPY                                = 0xfffffff007081dc0;
+        OFFSET_COPYIN                               = 0xfffffff0071811ec;
+        OFFSET_COPYOUT                              = 0xfffffff0071813e0;
+        OFFSET_CHGPROCCNT                           = 0xfffffff007049dff;
+        OFFSET_KAUTH_CRED_REF                       = 0xfffffff007368be4;
+        OFFSET_KAUTH_CRED_UNREF                     = 0xfffffff0073688c4;
+        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006526178;
+        OFFSET_ROP_LDR_X0_X0_0x10                   = 0xfffffff00748a4b4;
+        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075a80b0;
+    }
+    
     else
     {
         LOG("Device not supported.");

--- a/v0rtex-S/symbols.m
+++ b/v0rtex-S/symbols.m
@@ -81,6 +81,28 @@ BOOL init_symbols()
         OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
     }
     
+    // iPhone 6S (iPhone 8,1) 10.3.1
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:54 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T7000") == 0) {
+        OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+        OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+        OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+        OFFSET_REALHOST                             = 0xfffffff00753aba0;
+        OFFSET_BZERO                                = 0xfffffff00708df80;
+        OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+        OFFSET_COPYIN                               = 0xfffffff00718d3a8;
+        OFFSET_COPYOUT                              = 0xfffffff00718d59c;
+        OFFSET_CHGPROCCNT                           = 0xfffffff007055e7d;
+        OFFSET_KAUTH_CRED_REF                       = 0xfffffff007374b2c;
+        OFFSET_KAUTH_CRED_UNREF                     = 0xfffffff00737480c;
+        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a611c;
+        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b9374;
+        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5c40;
+        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eee1b8;
+        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b5178;
+        OFFSET_ROP_LDR_X0_X0_0x10                   = 0xfffffff0074961a8;
+        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075b40b0;
+    }
+    
     else
     {
         LOG("Device not supported.");


### PR DESCRIPTION
Added the 6S (8,1) 10.3.1 offsets that are supposed to work with the AMFI patch...
Still trying to find the OSSerialize offset tho so if you know anything about it please tell me, and thanks.