### PR TITLE
nvpatch + offset loading

### DIFF
--- a/v0rtex-S/Base.lproj/Main.storyboard
+++ b/v0rtex-S/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -49,7 +49,7 @@
                                 <color key="backgroundColor" red="0.92143100499999997" green="0.92145264149999995" blue="0.92144101860000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                 <color key="tintColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="run sploit">
+                                <state key="normal" title="go">
                                     <color key="titleColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>

--- a/v0rtex-S/Info.plist
+++ b/v0rtex-S/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>v0rtex-S</string>
+	<string>v0rtex</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/v0rtex-S/arch.h
+++ b/v0rtex-S/arch.h
@@ -1,0 +1,30 @@
+/*
+ * arch.h - Code to deal with different architectures.
+ *          Taken from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016-2017 Siguza
+ */
+
+#ifndef ARCH_H
+#define ARCH_H
+
+#include <mach-o/loader.h>      // mach_header, mach_header_64, segment_command, segment_command_64
+#include <Foundation/Foundation.h> // NSLog
+#include "common.h"
+
+#define IMAGE_OFFSET 0x2000
+#define MACH_TYPE CPU_TYPE_ARM64
+#define SIZE "%lu"
+#define MACH_HEADER_MAGIC MH_MAGIC_64
+#define MACH_LC_SEGMENT LC_SEGMENT_64
+#define MACH_LC_SEGMENT_NAME "LC_SEGMENT_64"
+#define KERNEL_SPACE 0x8000000000000000
+typedef struct mach_header_64 mach_hdr_t;
+typedef struct segment_command_64 mach_seg_t;
+typedef struct section_64 mach_sec_t;
+typedef struct load_command mach_lc_t;
+
+
+
+#endif

--- a/v0rtex-S/mach-o.h
+++ b/v0rtex-S/mach-o.h
@@ -1,0 +1,23 @@
+/*
+ * mach-o.h - Code that deals with the Mach-O file format
+ *            Taken from kern-utils
+ *
+ * Copyright (c) 2012 comex
+ * Copyright (c) 2016 Siguza
+ */
+
+#ifndef MACH_O_H
+#define MACH_O_H
+
+#include <mach-o/loader.h>      // load_command
+
+/*
+ * Iterate over all load commands in a Mach-O header
+ */
+#define CMD_ITERATE(hdr, cmd) \
+for(struct load_command *cmd = (struct load_command *) ((hdr) + 1), \
+                        *end = (struct load_command *) ((char *) cmd + (hdr)->sizeofcmds); \
+    cmd < end; \
+    cmd = (struct load_command *) ((char *) cmd + cmd->cmdsize))
+
+#endif

--- a/v0rtex-S/nvpatch.h
+++ b/v0rtex-S/nvpatch.h
@@ -1,0 +1,27 @@
+/*
+ * nvpatch.h - Patch kernel to unrestrict NVRAM variables
+ *             Taken and modified from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016 Pupyshev Nikita
+ * Copyright (c) 2017 Siguza
+ */
+
+#ifndef NVPATCH_H
+#define NVPATCH_H
+
+#include <stdio.h>
+#include <mach/mach.h>
+
+#define MAX_HEADER_SIZE 0x4000
+
+typedef struct
+{
+    vm_address_t addr;
+    vm_size_t len;
+    char *buf;
+} segment_t;
+
+int nvpatch(task_t kernel_task, vm_address_t kbase, const char *target);
+
+#endif

--- a/v0rtex-S/nvpatch.m
+++ b/v0rtex-S/nvpatch.m
@@ -1,0 +1,309 @@
+/*
+ * nvpatch.m - Patch kernel to unrestrict NVRAM variables
+ *             Taken and modified from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016 Pupyshev Nikita
+ * Copyright (c) 2017 Siguza
+ */
+
+#include <errno.h>              // errno
+#include <stdio.h>              // fprintf, stderr
+#include <stdlib.h>             // free, malloc
+#include <string.h>             // memmem, strcmp, strnlen
+
+#include "arch.h"               // ADDR, MACH_*, mach_*
+#include "mach-o.h"             // CMD_ITERATE
+
+#include "nvpatch.h"
+
+#define STRING_SEG  "__TEXT"
+#define STRING_SEC  "__cstring"
+#define OFVAR_SEG   "__DATA"
+#define OFVAR_SEC   "__data"
+
+enum
+{
+    kOFVarTypeBoolean = 1,
+    kOFVarTypeNumber,
+    kOFVarTypeString,
+    kOFVarTypeData,
+};
+
+enum
+{
+    kOFVarPermRootOnly = 0,
+    kOFVarPermUserRead,
+    kOFVarPermUserWrite,
+    kOFVarPermKernelOnly,
+};
+
+typedef struct
+{
+    vm_address_t name;
+    uint32_t type;
+    uint32_t perm;
+    int32_t offset;
+} OFVar;
+
+#define MAX_CHUNK_SIZE 0xFFF /* MIG limitation */
+
+static vm_size_t kernel_read(task_t kernel_task, vm_address_t addr, vm_size_t size, void *buf)
+{
+    kern_return_t ret;
+    vm_size_t remainder = size,
+              bytes_read = 0;
+
+    // The vm_* APIs are part of the mach_vm subsystem, which is a MIG thing
+    // and therefore has a hard limit of 0x1000 bytes that it accepts. Due to
+    // this, we have to do both reading and writing in chunks smaller than that.
+    for(vm_address_t end = addr + size; addr < end; remainder -= size)
+    {
+        size = remainder > MAX_CHUNK_SIZE ? MAX_CHUNK_SIZE : remainder;
+        ret = vm_read_overwrite(kernel_task, addr, size, (vm_address_t)&((char*)buf)[bytes_read], &size);
+        if(ret != KERN_SUCCESS || size == 0)
+        {
+            LOG("vm_read error: %s", mach_error_string(ret));
+            break;
+        }
+        bytes_read += size;
+        addr += size;
+    }
+
+    return bytes_read;
+}
+
+static vm_size_t kernel_write(task_t kernel_task, vm_address_t addr, vm_size_t size, void *buf)
+{
+    kern_return_t ret;
+    vm_size_t remainder = size,
+              bytes_written = 0;
+
+    for(vm_address_t end = addr + size; addr < end; remainder -= size)
+    {
+        size = remainder > MAX_CHUNK_SIZE ? MAX_CHUNK_SIZE : remainder;
+        ret = vm_write(kernel_task, addr, (vm_offset_t)&((char*)buf)[bytes_written], (mach_msg_type_number_t)size);
+        if(ret != KERN_SUCCESS)
+        {
+            LOG("vm_write error: %s", mach_error_string(ret));
+            break;
+        }
+        bytes_written += size;
+        addr += size;
+    }
+
+    return bytes_written;
+}
+
+int nvpatch(task_t kernel_task, vm_address_t kbase, const char *target)
+{
+    mach_hdr_t *hdr = malloc(MAX_HEADER_SIZE);
+    if(hdr == NULL)
+    {
+        LOG("Failed to allocate header buffer (%s)", strerror(errno));
+        return -1;
+    }
+    memset(hdr, 0, MAX_HEADER_SIZE);
+
+    LOG("Reading kernel header...");
+    if(kernel_read(kernel_task, kbase, MAX_HEADER_SIZE, hdr) != MAX_HEADER_SIZE)
+    {
+        LOG("Kernel I/O error");
+        return -1;
+    }
+
+    segment_t
+    cstring =
+    {
+        .addr = 0,
+        .len = 0,
+        .buf = NULL,
+    },
+    data =
+    {
+        .addr = 0,
+        .len = 0,
+        .buf = NULL,
+    };
+    CMD_ITERATE(hdr, cmd)
+    {
+        switch(cmd->cmd)
+        {
+            case MACH_LC_SEGMENT:
+                {
+                    mach_seg_t *seg = (mach_seg_t*)cmd;
+                    mach_sec_t *sec = (mach_sec_t*)(seg + 1);
+                    for(size_t i = 0; i < seg->nsects; ++i)
+                    {
+                        if(strcmp(sec[i].segname, STRING_SEG) == 0 && strcmp(sec[i].sectname, STRING_SEC) == 0)
+                        {
+                            LOG("Found " STRING_SEG "." STRING_SEC " section at " ADDR, (vm_address_t)sec[i].addr);
+                            cstring.addr = sec[i].addr;
+                            cstring.len = sec[i].size;
+                            cstring.buf = malloc(cstring.len);
+                            if(cstring.buf == NULL)
+                            {
+                                LOG("Failed to allocate section buffer (%s)", strerror(errno));
+                                return -1;
+                            }
+                            if(kernel_read(kernel_task, cstring.addr, cstring.len, cstring.buf) != cstring.len)
+                            {
+                                LOG("Kernel I/O error");
+                                return -1;
+                            }
+                        }
+                        else if(strcmp(sec[i].segname, OFVAR_SEG) == 0 && strcmp(sec[i].sectname, OFVAR_SEC) == 0)
+                        {
+                            LOG("Found " OFVAR_SEG "." OFVAR_SEC " section at " ADDR, (vm_address_t)sec[i].addr);
+                            data.addr = sec[i].addr;
+                            data.len = sec[i].size;
+                            data.buf = malloc(data.len);
+                            if(data.buf == NULL)
+                            {
+                                LOG("Failed to allocate section buffer (%s)", strerror(errno));
+                                return -1;
+                            }
+                            if(kernel_read(kernel_task, data.addr, data.len, data.buf) != data.len)
+                            {
+                                LOG("Kernel I/O error");
+                                return -1;
+                            }
+                        }
+                    }
+                }
+                break;
+        }
+    }
+    if(cstring.buf == NULL)
+    {
+        LOG("Failed to find " STRING_SEG "." STRING_SEC " section");
+        return -1;
+    }
+    if(data.buf == NULL)
+    {
+        LOG("Failed to find " OFVAR_SEG "." OFVAR_SEC " section");
+        return -1;
+    }
+
+    // This is the name of the first NVRAM variable
+    char first[] = "little-endian?";
+    char *str = memmem(cstring.buf, cstring.len, first, sizeof(first));
+    if(str == NULL)
+    {
+        LOG("Failed to find string \"%s\"", first);
+        return -1;
+    }
+    vm_address_t str_addr = (str - cstring.buf) + cstring.addr;
+    LOG("Found string \"%s\" at " ADDR, first, str_addr);
+
+    // Now let's find a reference to it
+    OFVar *gOFVars = NULL;
+    for(vm_address_t *ptr = (vm_address_t*)data.buf, *end = (vm_address_t*)&data.buf[data.len]; ptr < end; ++ptr)
+    {
+        if(*ptr == str_addr)
+        {
+            gOFVars = (OFVar*)ptr;
+            break;
+        }
+    }
+    if(gOFVars == NULL)
+    {
+        LOG("Failed to find gOFVariables");
+        return -1;
+    }
+    vm_address_t gOFAddr = ((char*)gOFVars - data.buf) + data.addr;
+    LOG("Found gOFVariables at " ADDR, gOFAddr);
+
+    // Sanity checks
+    size_t numvars = 0,
+           longest_name = 0;
+    for(OFVar *var = gOFVars; (char*)var < &data.buf[data.len]; ++var)
+    {
+        if(var->name == 0) // End marker
+        {
+            break;
+        }
+        if(var->name < cstring.addr || var->name >= cstring.addr + cstring.len)
+        {
+            LOG("gOFVariables[%lu].name is out of bounds", numvars);
+            return -1;
+        }
+        char *name = &cstring.buf[var->name - cstring.addr];
+        size_t maxlen = cstring.len - (name - cstring.buf),
+               namelen = strnlen(name, maxlen);
+        if(namelen == maxlen)
+        {
+            LOG("gOFVariables[%lu].name exceeds __cstring size", numvars);
+            return -1;
+        }
+        for(size_t i = 0; i < namelen; ++i)
+        {
+            if(name[i] < 0x20 || name[i] >= 0x7f)
+            {
+                LOG("gOFVariables[%lu].name contains non-printable character: 0x%02x", numvars, name[i]);
+                return -1;
+            }
+        }
+        longest_name = namelen > longest_name ? namelen : longest_name;
+        switch(var->type)
+        {
+            case kOFVarTypeBoolean:
+            case kOFVarTypeNumber:
+            case kOFVarTypeString:
+            case kOFVarTypeData:
+                break;
+            default:
+                LOG("gOFVariables[%lu] has unknown type: 0x%x", numvars, var->type);
+                return -1;
+        }
+        switch(var->perm)
+        {
+            case kOFVarPermRootOnly:
+            case kOFVarPermUserRead:
+            case kOFVarPermUserWrite:
+            case kOFVarPermKernelOnly:
+                break;
+            default:
+                LOG("gOFVariables[%lu] has unknown permissions: 0x%x", numvars, var->perm);
+                return -1;
+        }
+        ++numvars;
+    }
+    if(numvars < 1)
+    {
+        LOG("gOFVariables contains zero entries");
+        return -1;
+    }
+
+    for(size_t i = 0; i < numvars; ++i)
+    {
+        char *name = &cstring.buf[gOFVars[i].name - cstring.addr];
+        if(strcmp(name, target) == 0)
+        {
+            if(gOFVars[i].perm != kOFVarPermKernelOnly)
+            {
+                LOG("Variable \"%s\" is already writable for %s", target, gOFVars[i].perm == kOFVarPermUserWrite ? "everyone" : "root");
+                goto done;
+            }
+            vm_size_t off = ((char*)&gOFVars[i].perm) - data.buf;
+            uint32_t newperm = kOFVarPermUserWrite; // was kOFVarPermRootOnly
+            if(kernel_write(kernel_task, data.addr + off, sizeof(newperm), &newperm) != sizeof(newperm))
+            {
+                LOG("Kernel I/O error");
+                return -1;
+            }
+            LOG("Successfully patched permissions for variable \"%s\"", target);
+            goto done;
+        }
+    }
+    LOG("Failed to find variable \"%s\"", target);
+    return -1;
+
+    done:;
+
+    free(cstring.buf);
+    free(data.buf);
+    free(hdr);
+
+    return 0;
+}

--- a/v0rtex-S/symbols.h
+++ b/v0rtex-S/symbols.h
@@ -12,6 +12,7 @@
 #include <strings.h>
 #include "common.h"
 
+
 extern uint64_t OFFSET_ZONE_MAP;
 extern uint64_t OFFSET_KERNEL_MAP;
 extern uint64_t OFFSET_KERNEL_TASK;
@@ -27,4 +28,4 @@ extern uint64_t OFFSET_IOSURFACEROOTUSERCLIENT_VTAB;
 extern uint64_t OFFSET_ROP_ADD_X0_X0_0x10;
 extern uint64_t OFFSET_ROOT_MOUNT_V_NODE;
 
-BOOL init_symbols(void);
+int load_offsets(void);

--- a/v0rtex-S/symbols.m
+++ b/v0rtex-S/symbols.m
@@ -9,6 +9,7 @@
 #include <sys/utsname.h>
 #include "symbols.h"
 #include "common.h"
+#include <sys/sysctl.h>
 
 uint64_t OFFSET_ZONE_MAP;
 uint64_t OFFSET_KERNEL_MAP;
@@ -25,59 +26,1491 @@ uint64_t OFFSET_IOSURFACEROOTUSERCLIENT_VTAB;
 uint64_t OFFSET_ROP_ADD_X0_X0_0x10;
 uint64_t OFFSET_ROOT_MOUNT_V_NODE;
 
-BOOL init_symbols()
+int load_offsets(void)
 {
-    struct utsname u;
-    uname(&u);
+    struct utsname sysinfo;
+    uname(&sysinfo);
     
-    LOG("sysname: %s", u.sysname);
-    LOG("nodename: %s", u.nodename);
-    LOG("release: %s", u.release);
-    LOG("version: %s", u.version);
-    LOG("machine: %s", u.machine);
+    //read device id
+    int d_prop[2] = {CTL_HW, HW_MACHINE};
+    char device[20];
+    size_t d_prop_len = sizeof(device);
+    //sysctl(d_prop, 2, NULL, &d_prop_len, NULL, 0);
+    sysctl(d_prop, 2, device, &d_prop_len, NULL, 0);
     
+    int version_prop[2] = {CTL_KERN, KERN_OSVERSION};
+    char version[20];
+    size_t version_prop_len = sizeof(version);
+    //sysctl(version_prop, 2, NULL, &version_prop_len, NULL, 0);
+    sysctl(version_prop, 2, version, &version_prop_len, NULL, 0);
     
-    // iPhone 7 (iPhone9,3) 10.3.1
-    if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:55 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T8010") == 0) {
-        OFFSET_ZONE_MAP                             = 0xfffffff007590478;
-        OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
-        OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
-        OFFSET_REALHOST                             = 0xfffffff007572ba0;
-        OFFSET_BZERO                                = 0xfffffff0070c1f80;
-        OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
-        OFFSET_COPYIN                               = 0xfffffff0071c6134;
-        OFFSET_COPYOUT                              = 0xfffffff0071c6414;
-        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070df05c;
-        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22b4;
-        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb80;
-        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e4a238;
-        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064ff0a8;
-        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
-    }
+    //return 1;
     
-    // iPhone8,1 10.3.2
-    else if (strcmp(u.version, "Darwin Kernel Version 16.6.0: Mon Apr 17 17:33:34 PDT 2017; root:xnu-3789.60.24~24/RELEASE_ARM64_S8000") == 0) {
-        OFFSET_ZONE_MAP                             = 0xfffffff007548478;
-        OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
-        OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
-        OFFSET_REALHOST                             = 0xfffffff00752aba0;
-        OFFSET_BZERO                                = 0xfffffff007081f80;
-        OFFSET_BCOPY                                = 0xfffffff007081dc0;
-        OFFSET_COPYIN                               = 0xfffffff0071806f4;
-        OFFSET_COPYOUT                              = 0xfffffff0071808e8;
-        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
-        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
-        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
-        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e7c9f8;
-        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006b916b8;
-        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
-    }
-    else
+    //iPad 4 (WiFi)
+    if(!strcmp(device, "iPad3,4"))
     {
-        LOG("Device not supported.");
-        return FALSE;
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
     }
     
-    return TRUE;
+    //iPad 4 (GSM)
+    if(!strcmp(device, "iPad3,5"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad 4 (Global)
+    if(!strcmp(device, "iPad3,6"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Air (WiFi)
+    if(!strcmp(device, "iPad4,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Air (Cellular)
+    if(!strcmp(device, "iPad4,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Air (China)
+    if(!strcmp(device, "iPad4,3"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 2 (WiFi)
+    if(!strcmp(device, "iPad4,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            OFFSET_COPYIN                               = 0xfffffff007181218;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+            OFFSET_REALHOST                             = 0xfffffff00752eba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1d4;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fd174;
+            OFFSET_COPYOUT                              = 0xfffffff00718140c;
+            OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f7c;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f2e338;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099aa0;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 2 (Cellular)
+    if(!strcmp(device, "iPad4,5"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+            OFFSET_REALHOST                             = 0xfffffff00752eba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff007180e98;
+            OFFSET_COPYOUT                              = 0xfffffff00718108c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f2e338;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fe174;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 2 (China)
+    if(!strcmp(device, "iPad4,6"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 3 (WiFi)
+    if(!strcmp(device, "iPad4,7"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 3 (Cellular)
+    if(!strcmp(device, "iPad4,8"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 3 (China)
+    if(!strcmp(device, "iPad4,9"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 4 (WiFi)
+    if(!strcmp(device, "iPad5,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Mini 4 (Cellular)
+    if(!strcmp(device, "iPad5,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F91"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Air 2 (WiFi)
+    if(!strcmp(device, "iPad5,3"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Air 2 (Cellular)
+    if(!strcmp(device, "iPad5,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad 5 (WiFi)
+    if(!strcmp(device, "iPad6,11"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F90"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad 5 (Cellular)
+    if(!strcmp(device, "iPad6,12"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F90"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 9.7-inch (WiFi)
+    if(!strcmp(device, "iPad6,3"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 9.7-inch (Cellular)
+    if(!strcmp(device, "iPad6,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 12.9-inch (WiFi)
+    if(!strcmp(device, "iPad6,7"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 12.9-inch (Cellular)
+    if(!strcmp(device, "iPad6,8"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 2 (12.9-inch, WiFi)
+    if(!strcmp(device, "iPad7,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F8089"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro 2 (12.9-inch, Cellular)
+    if(!strcmp(device, "iPad7,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F8089"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro (10.5-inch, WiFi)
+    if(!strcmp(device, "iPad7,3"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F8089"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPad Pro (10.5-inch, Cellular)
+    if(!strcmp(device, "iPad7,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F8089"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 5 (GSM)
+    if(!strcmp(device, "iPhone5,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 5 (Global)
+    if(!strcmp(device, "iPhone5,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 5c (GSM)
+    if(!strcmp(device, "iPhone5,3"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 5c (Global)
+    if(!strcmp(device, "iPhone5,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    
+    //iPhone 5s
+    if(!strcmp(device, "iPhone6,2") || !strcmp(device, "iPhone6,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+            OFFSET_REALHOST                             = 0xfffffff00752eba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff007180e98;
+            OFFSET_COPYOUT                              = 0xfffffff00718108c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006522174;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+            OFFSET_REALHOST                             = 0xfffffff00752eba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071811ec;
+            OFFSET_COPYOUT                              = 0xfffffff0071813e0;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006526174;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+            OFFSET_REALHOST                             = 0xfffffff00752eba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff007181218;
+            OFFSET_COPYOUT                              = 0xfffffff00718140c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f7c;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1d4;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099aa0;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006525174;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 6+
+    if(!strcmp(device, "iPhone7,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 6
+    if(!strcmp(device, "iPhone7,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+            OFFSET_REALHOST                             = 0xfffffff00753aba0;
+            OFFSET_BZERO                                = 0xfffffff00708df80;
+            OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+            OFFSET_COPYIN                               = 0xfffffff00718d028;
+            OFFSET_COPYOUT                              = 0xfffffff00718d21c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a60b4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b938c;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5bd8;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006135000 + 0x1030;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b2174;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+            OFFSET_REALHOST                             = 0xfffffff00753aba0;
+            OFFSET_BZERO                                = 0xfffffff00708df80;
+            OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+            OFFSET_COPYIN                               = 0xfffffff00718d37c;
+            OFFSET_COPYOUT                              = 0xfffffff00718d570;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a60b4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b938c;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5bd8;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eee1b8;
+            //OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b2174;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006642c90;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+            OFFSET_REALHOST                             = 0xfffffff00753aba0;
+            OFFSET_BZERO                                = 0xfffffff00708df80;
+            OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+            OFFSET_COPYIN                               = 0xfffffff00718d3a8;
+            OFFSET_COPYOUT                              = 0xfffffff00718d59c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a611c;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b9374;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5c40;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eed2b8;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b5174;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 6s
+    if(!strcmp(device, "iPhone8,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
+            OFFSET_REALHOST                             = 0xfffffff00752aba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071803a0;
+            OFFSET_COPYOUT                              = 0xfffffff007180594;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e7c9f8;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006462174;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
+            OFFSET_REALHOST                             = 0xfffffff00752aba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff007081dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071806f4;
+            OFFSET_COPYOUT                              = 0xfffffff0071808e8;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e7c9f8;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b1398;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 6s+
+    if(!strcmp(device, "iPhone8,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone SE
+    if(!strcmp(device, "iPhone8,4"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff007081dc0;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0071806f4;
+            OFFSET_REALHOST                             = 0xfffffff00752aba0;
+            OFFSET_BZERO                                = 0xfffffff007081f80;
+            OFFSET_BCOPY                                = 0xfffffff0071808e8;
+            OFFSET_COPYIN                               = 0xfffffff0075a4050;
+            OFFSET_COPYOUT                              = 0xfffffff0075a4048;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e849f8;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006482174;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 7
+    if(!strcmp(device, "iPhone9,3") || !strcmp(device, "iPhone9,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c5db4;
+            OFFSET_COPYOUT                              = 0xfffffff0071c6094;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            // OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c5398;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fb0a8;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c6108;
+            OFFSET_COPYOUT                              = 0xfffffff0071c63e8;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0065000a8;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c6134;
+            OFFSET_COPYOUT                              = 0xfffffff0071c6414;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070df05c;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22b4;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb80;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064ff0a8;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPhone 7 Plus
+    if(!strcmp(device, "iPhone9,4") || !strcmp(device, "iPhone9,2"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c5db4;
+            OFFSET_COPYOUT                              = 0xfffffff0071c6094;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            // OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c5398;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fb0a8;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c6108;
+            OFFSET_COPYOUT                              = 0xfffffff0071c63e8;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            // OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063ca398;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0065000a8;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+            OFFSET_REALHOST                             = 0xfffffff007572ba0;
+            OFFSET_BZERO                                = 0xfffffff0070c1f80;
+            OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+            OFFSET_COPYIN                               = 0xfffffff0071c6134;
+            OFFSET_COPYOUT                              = 0xfffffff0071c6414;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070df05c;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22b4;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb80;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+            // OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c9398;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064ff0a8;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    //iPod touch 6
+    if(!strcmp(device, "iPod7,1"))
+    {
+        //10.3.3
+        if(!strcmp(version, "14G60"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.2
+        if(!strcmp(version, "14F89"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3.1
+        if(!strcmp(version, "14E304"))
+        {
+            
+            return 1;
+        }
+        
+        //10.3
+        if(!strcmp(version, "14E277"))
+        {
+            
+            return 1;
+        }
+        
+        
+    }
+    
+    
+    LOG("%s", sysinfo.version);
+    LOG("loading offsets for %s - %s", device, version);
+    LOG("test offset x0x0x10gadget: %llx", OFFSET_ROP_ADD_X0_X0_0x10);
+    
+    return 0;
 }
-

--- a/v0rtex-s.xcodeproj/project.pbxproj
+++ b/v0rtex-s.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		815EBEBE1FEBA6C20066C616 /* nvpatch.m in Sources */ = {isa = PBXBuildFile; fileRef = 815EBEBB1FEBA6C20066C616 /* nvpatch.m */; };
 		B58B32401FE4EBA300EB7B47 /* kernel.m in Sources */ = {isa = PBXBuildFile; fileRef = B58B323D1FE4EBA300EB7B47 /* kernel.m */; };
 		B58B32441FE4ED3B00EB7B47 /* ls in Resources */ = {isa = PBXBuildFile; fileRef = B58B32431FE4ED3B00EB7B47 /* ls */; };
 		B58B32461FE4ED6300EB7B47 /* symbols.m in Sources */ = {isa = PBXBuildFile; fileRef = B58B32451FE4ED6300EB7B47 /* symbols.m */; };
@@ -23,6 +24,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		815EBEBA1FEBA6C20066C616 /* arch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = arch.h; sourceTree = "<group>"; };
+		815EBEBB1FEBA6C20066C616 /* nvpatch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = nvpatch.m; sourceTree = "<group>"; };
+		815EBEBC1FEBA6C20066C616 /* mach-o.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "mach-o.h"; sourceTree = "<group>"; };
+		815EBEBD1FEBA6C20066C616 /* nvpatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nvpatch.h; sourceTree = "<group>"; };
 		B58B323D1FE4EBA300EB7B47 /* kernel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = kernel.m; sourceTree = "<group>"; };
 		B58B323F1FE4EBA300EB7B47 /* kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel.h; sourceTree = "<group>"; };
 		B58B32431FE4ED3B00EB7B47 /* ls */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = ls; sourceTree = "<group>"; };
@@ -83,6 +88,10 @@
 				EEAC27D31FDDB0A3003C1801 /* Supporting Files */,
 				B58B32431FE4ED3B00EB7B47 /* ls */,
 				EE5252BB1FDA4F2F00993801 /* main.m */,
+				815EBEBA1FEBA6C20066C616 /* arch.h */,
+				815EBEBC1FEBA6C20066C616 /* mach-o.h */,
+				815EBEBD1FEBA6C20066C616 /* nvpatch.h */,
+				815EBEBB1FEBA6C20066C616 /* nvpatch.m */,
 				EE5252AC1FDA4F2F00993801 /* AppDelegate.h */,
 				EE5252AD1FDA4F2F00993801 /* AppDelegate.m */,
 				EE5252AF1FDA4F2F00993801 /* ViewController.h */,
@@ -192,6 +201,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				815EBEBE1FEBA6C20066C616 /* nvpatch.m in Sources */,
 				B58B32491FE4F3DF00EB7B47 /* root-rw.m in Sources */,
 				B58B32401FE4EBA300EB7B47 /* kernel.m in Sources */,
 				B58B32461FE4ED6300EB7B47 /* symbols.m in Sources */,
@@ -336,10 +346,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6EKJWC698P;
+				DEVELOPMENT_TEAM = WATF666TG9;
 				INFOPLIST_FILE = "$(SRCROOT)/v0rtex-S/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sticktron.v0rtex;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.xninja.v0rtex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -352,10 +362,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6EKJWC698P;
+				DEVELOPMENT_TEAM = WATF666TG9;
 				INFOPLIST_FILE = "$(SRCROOT)/v0rtex-S/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sticktron.v0rtex;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.xninja.v0rtex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
- use sysctl calls to get hw identifier and current build id
- organized device, build id blocks to add offset for every possible device that has 10.3 - 10.3.3
- log test offset, device identifier, build id, kern version to console so that you can actually check if it loads the offset 
- changed some return values and comparisons to match C standards 
- removed ObjectiveC-ish comparisons for identifying device + buildid combinations 

Patches the nvram variable 'com.apple.System.boot-nonce' to enable users to set generator.
note : this has to be done as part of the exploit as we have both kernel task and kernel base address. Getting these in a different tool is not that easy. Requires getting tfp0 and kernel base address. 