### PR TITLE
nvram boot-nonce patch, more elegant offset loading

### DIFF
--- a/v0rtex-S/Base.lproj/Main.storyboard
+++ b/v0rtex-S/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -49,7 +49,7 @@
                                 <color key="backgroundColor" red="0.92143100499999997" green="0.92145264149999995" blue="0.92144101860000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                 <color key="tintColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="run sploit">
+                                <state key="normal" title="Go">
                                     <color key="titleColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>

--- a/v0rtex-S/arch.h
+++ b/v0rtex-S/arch.h
@@ -1,0 +1,30 @@
+/*
+ * arch.h - Code to deal with different architectures.
+ *          Taken from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016-2017 Siguza
+ */
+
+#ifndef ARCH_H
+#define ARCH_H
+
+#include <mach-o/loader.h>      // mach_header, mach_header_64, segment_command, segment_command_64
+#include <Foundation/Foundation.h> // NSLog
+#include "common.h"
+
+#define IMAGE_OFFSET 0x2000
+#define MACH_TYPE CPU_TYPE_ARM64
+#define SIZE "%lu"
+#define MACH_HEADER_MAGIC MH_MAGIC_64
+#define MACH_LC_SEGMENT LC_SEGMENT_64
+#define MACH_LC_SEGMENT_NAME "LC_SEGMENT_64"
+#define KERNEL_SPACE 0x8000000000000000
+typedef struct mach_header_64 mach_hdr_t;
+typedef struct segment_command_64 mach_seg_t;
+typedef struct section_64 mach_sec_t;
+typedef struct load_command mach_lc_t;
+
+
+
+#endif

--- a/v0rtex-S/mach-o.h
+++ b/v0rtex-S/mach-o.h
@@ -1,0 +1,23 @@
+/*
+ * mach-o.h - Code that deals with the Mach-O file format
+ *            Taken from kern-utils
+ *
+ * Copyright (c) 2012 comex
+ * Copyright (c) 2016 Siguza
+ */
+
+#ifndef MACH_O_H
+#define MACH_O_H
+
+#include <mach-o/loader.h>      // load_command
+
+/*
+ * Iterate over all load commands in a Mach-O header
+ */
+#define CMD_ITERATE(hdr, cmd) \
+for(struct load_command *cmd = (struct load_command *) ((hdr) + 1), \
+                        *end = (struct load_command *) ((char *) cmd + (hdr)->sizeofcmds); \
+    cmd < end; \
+    cmd = (struct load_command *) ((char *) cmd + cmd->cmdsize))
+
+#endif

--- a/v0rtex-S/nvpatch.h
+++ b/v0rtex-S/nvpatch.h
@@ -1,0 +1,27 @@
+/*
+ * nvpatch.h - Patch kernel to unrestrict NVRAM variables
+ *             Taken and modified from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016 Pupyshev Nikita
+ * Copyright (c) 2017 Siguza
+ */
+
+#ifndef NVPATCH_H
+#define NVPATCH_H
+
+#include <stdio.h>
+#include <mach/mach.h>
+
+#define MAX_HEADER_SIZE 0x4000
+
+typedef struct
+{
+    vm_address_t addr;
+    vm_size_t len;
+    char *buf;
+} segment_t;
+
+int nvpatch(task_t kernel_task, vm_address_t kbase, const char *target);
+
+#endif

--- a/v0rtex-S/nvpatch.m
+++ b/v0rtex-S/nvpatch.m
@@ -1,0 +1,309 @@
+/*
+ * nvpatch.m - Patch kernel to unrestrict NVRAM variables
+ *             Taken and modified from kern-utils
+ *
+ * Copyright (c) 2014 Samuel Groß
+ * Copyright (c) 2016 Pupyshev Nikita
+ * Copyright (c) 2017 Siguza
+ */
+
+#include <errno.h>              // errno
+#include <stdio.h>              // fprintf, stderr
+#include <stdlib.h>             // free, malloc
+#include <string.h>             // memmem, strcmp, strnlen
+
+#include "arch.h"               // ADDR, MACH_*, mach_*
+#include "mach-o.h"             // CMD_ITERATE
+
+#include "nvpatch.h"
+
+#define STRING_SEG  "__TEXT"
+#define STRING_SEC  "__cstring"
+#define OFVAR_SEG   "__DATA"
+#define OFVAR_SEC   "__data"
+
+enum
+{
+    kOFVarTypeBoolean = 1,
+    kOFVarTypeNumber,
+    kOFVarTypeString,
+    kOFVarTypeData,
+};
+
+enum
+{
+    kOFVarPermRootOnly = 0,
+    kOFVarPermUserRead,
+    kOFVarPermUserWrite,
+    kOFVarPermKernelOnly,
+};
+
+typedef struct
+{
+    vm_address_t name;
+    uint32_t type;
+    uint32_t perm;
+    int32_t offset;
+} OFVar;
+
+#define MAX_CHUNK_SIZE 0xFFF /* MIG limitation */
+
+static vm_size_t kernel_read(task_t kernel_task, vm_address_t addr, vm_size_t size, void *buf)
+{
+    kern_return_t ret;
+    vm_size_t remainder = size,
+              bytes_read = 0;
+
+    // The vm_* APIs are part of the mach_vm subsystem, which is a MIG thing
+    // and therefore has a hard limit of 0x1000 bytes that it accepts. Due to
+    // this, we have to do both reading and writing in chunks smaller than that.
+    for(vm_address_t end = addr + size; addr < end; remainder -= size)
+    {
+        size = remainder > MAX_CHUNK_SIZE ? MAX_CHUNK_SIZE : remainder;
+        ret = vm_read_overwrite(kernel_task, addr, size, (vm_address_t)&((char*)buf)[bytes_read], &size);
+        if(ret != KERN_SUCCESS || size == 0)
+        {
+            LOG("vm_read error: %s", mach_error_string(ret));
+            break;
+        }
+        bytes_read += size;
+        addr += size;
+    }
+
+    return bytes_read;
+}
+
+static vm_size_t kernel_write(task_t kernel_task, vm_address_t addr, vm_size_t size, void *buf)
+{
+    kern_return_t ret;
+    vm_size_t remainder = size,
+              bytes_written = 0;
+
+    for(vm_address_t end = addr + size; addr < end; remainder -= size)
+    {
+        size = remainder > MAX_CHUNK_SIZE ? MAX_CHUNK_SIZE : remainder;
+        ret = vm_write(kernel_task, addr, (vm_offset_t)&((char*)buf)[bytes_written], (mach_msg_type_number_t)size);
+        if(ret != KERN_SUCCESS)
+        {
+            LOG("vm_write error: %s", mach_error_string(ret));
+            break;
+        }
+        bytes_written += size;
+        addr += size;
+    }
+
+    return bytes_written;
+}
+
+int nvpatch(task_t kernel_task, vm_address_t kbase, const char *target)
+{
+    mach_hdr_t *hdr = malloc(MAX_HEADER_SIZE);
+    if(hdr == NULL)
+    {
+        LOG("Failed to allocate header buffer (%s)", strerror(errno));
+        return -1;
+    }
+    memset(hdr, 0, MAX_HEADER_SIZE);
+
+    LOG("Reading kernel header...");
+    if(kernel_read(kernel_task, kbase, MAX_HEADER_SIZE, hdr) != MAX_HEADER_SIZE)
+    {
+        LOG("Kernel I/O error");
+        return -1;
+    }
+
+    segment_t
+    cstring =
+    {
+        .addr = 0,
+        .len = 0,
+        .buf = NULL,
+    },
+    data =
+    {
+        .addr = 0,
+        .len = 0,
+        .buf = NULL,
+    };
+    CMD_ITERATE(hdr, cmd)
+    {
+        switch(cmd->cmd)
+        {
+            case MACH_LC_SEGMENT:
+                {
+                    mach_seg_t *seg = (mach_seg_t*)cmd;
+                    mach_sec_t *sec = (mach_sec_t*)(seg + 1);
+                    for(size_t i = 0; i < seg->nsects; ++i)
+                    {
+                        if(strcmp(sec[i].segname, STRING_SEG) == 0 && strcmp(sec[i].sectname, STRING_SEC) == 0)
+                        {
+                            LOG("Found " STRING_SEG "." STRING_SEC " section at " ADDR, (vm_address_t)sec[i].addr);
+                            cstring.addr = sec[i].addr;
+                            cstring.len = sec[i].size;
+                            cstring.buf = malloc(cstring.len);
+                            if(cstring.buf == NULL)
+                            {
+                                LOG("Failed to allocate section buffer (%s)", strerror(errno));
+                                return -1;
+                            }
+                            if(kernel_read(kernel_task, cstring.addr, cstring.len, cstring.buf) != cstring.len)
+                            {
+                                LOG("Kernel I/O error");
+                                return -1;
+                            }
+                        }
+                        else if(strcmp(sec[i].segname, OFVAR_SEG) == 0 && strcmp(sec[i].sectname, OFVAR_SEC) == 0)
+                        {
+                            LOG("Found " OFVAR_SEG "." OFVAR_SEC " section at " ADDR, (vm_address_t)sec[i].addr);
+                            data.addr = sec[i].addr;
+                            data.len = sec[i].size;
+                            data.buf = malloc(data.len);
+                            if(data.buf == NULL)
+                            {
+                                LOG("Failed to allocate section buffer (%s)", strerror(errno));
+                                return -1;
+                            }
+                            if(kernel_read(kernel_task, data.addr, data.len, data.buf) != data.len)
+                            {
+                                LOG("Kernel I/O error");
+                                return -1;
+                            }
+                        }
+                    }
+                }
+                break;
+        }
+    }
+    if(cstring.buf == NULL)
+    {
+        LOG("Failed to find " STRING_SEG "." STRING_SEC " section");
+        return -1;
+    }
+    if(data.buf == NULL)
+    {
+        LOG("Failed to find " OFVAR_SEG "." OFVAR_SEC " section");
+        return -1;
+    }
+
+    // This is the name of the first NVRAM variable
+    char first[] = "little-endian?";
+    char *str = memmem(cstring.buf, cstring.len, first, sizeof(first));
+    if(str == NULL)
+    {
+        LOG("Failed to find string \"%s\"", first);
+        return -1;
+    }
+    vm_address_t str_addr = (str - cstring.buf) + cstring.addr;
+    LOG("Found string \"%s\" at " ADDR, first, str_addr);
+
+    // Now let's find a reference to it
+    OFVar *gOFVars = NULL;
+    for(vm_address_t *ptr = (vm_address_t*)data.buf, *end = (vm_address_t*)&data.buf[data.len]; ptr < end; ++ptr)
+    {
+        if(*ptr == str_addr)
+        {
+            gOFVars = (OFVar*)ptr;
+            break;
+        }
+    }
+    if(gOFVars == NULL)
+    {
+        LOG("Failed to find gOFVariables");
+        return -1;
+    }
+    vm_address_t gOFAddr = ((char*)gOFVars - data.buf) + data.addr;
+    LOG("Found gOFVariables at " ADDR, gOFAddr);
+
+    // Sanity checks
+    size_t numvars = 0,
+           longest_name = 0;
+    for(OFVar *var = gOFVars; (char*)var < &data.buf[data.len]; ++var)
+    {
+        if(var->name == 0) // End marker
+        {
+            break;
+        }
+        if(var->name < cstring.addr || var->name >= cstring.addr + cstring.len)
+        {
+            LOG("gOFVariables[%lu].name is out of bounds", numvars);
+            return -1;
+        }
+        char *name = &cstring.buf[var->name - cstring.addr];
+        size_t maxlen = cstring.len - (name - cstring.buf),
+               namelen = strnlen(name, maxlen);
+        if(namelen == maxlen)
+        {
+            LOG("gOFVariables[%lu].name exceeds __cstring size", numvars);
+            return -1;
+        }
+        for(size_t i = 0; i < namelen; ++i)
+        {
+            if(name[i] < 0x20 || name[i] >= 0x7f)
+            {
+                LOG("gOFVariables[%lu].name contains non-printable character: 0x%02x", numvars, name[i]);
+                return -1;
+            }
+        }
+        longest_name = namelen > longest_name ? namelen : longest_name;
+        switch(var->type)
+        {
+            case kOFVarTypeBoolean:
+            case kOFVarTypeNumber:
+            case kOFVarTypeString:
+            case kOFVarTypeData:
+                break;
+            default:
+                LOG("gOFVariables[%lu] has unknown type: 0x%x", numvars, var->type);
+                return -1;
+        }
+        switch(var->perm)
+        {
+            case kOFVarPermRootOnly:
+            case kOFVarPermUserRead:
+            case kOFVarPermUserWrite:
+            case kOFVarPermKernelOnly:
+                break;
+            default:
+                LOG("gOFVariables[%lu] has unknown permissions: 0x%x", numvars, var->perm);
+                return -1;
+        }
+        ++numvars;
+    }
+    if(numvars < 1)
+    {
+        LOG("gOFVariables contains zero entries");
+        return -1;
+    }
+
+    for(size_t i = 0; i < numvars; ++i)
+    {
+        char *name = &cstring.buf[gOFVars[i].name - cstring.addr];
+        if(strcmp(name, target) == 0)
+        {
+            if(gOFVars[i].perm != kOFVarPermKernelOnly)
+            {
+                LOG("Variable \"%s\" is already writable for %s", target, gOFVars[i].perm == kOFVarPermUserWrite ? "everyone" : "root");
+                goto done;
+            }
+            vm_size_t off = ((char*)&gOFVars[i].perm) - data.buf;
+            uint32_t newperm = kOFVarPermUserWrite; // was kOFVarPermRootOnly
+            if(kernel_write(kernel_task, data.addr + off, sizeof(newperm), &newperm) != sizeof(newperm))
+            {
+                LOG("Kernel I/O error");
+                return -1;
+            }
+            LOG("Successfully patched permissions for variable \"%s\"", target);
+            goto done;
+        }
+    }
+    LOG("Failed to find variable \"%s\"", target);
+    return -1;
+
+    done:;
+
+    free(cstring.buf);
+    free(data.buf);
+    free(hdr);
+
+    return 0;
+}

--- a/v0rtex-S/symbols.h
+++ b/v0rtex-S/symbols.h
@@ -31,4 +31,4 @@ extern uint64_t OFFSET_ROP_LDR_X0_X0_0x10;
 extern uint64_t OFFSET_ROP_ADD_X0_X0_0x10;
 extern uint64_t OFFSET_ROOT_MOUNT_V_NODE;
 
-BOOL init_symbols(void);
+int init_symbols(void);

--- a/v0rtex-S/symbols.m
+++ b/v0rtex-S/symbols.m
@@ -36,21 +36,527 @@ int init_symbols()
 {
     struct utsname sysinfo;
     uname(&sysinfo);
-    
+
     //read device id
     int d_prop[2] = {CTL_HW, HW_MACHINE};
     char device[20];
     size_t d_prop_len = sizeof(device);
     //sysctl(d_prop, 2, NULL, &d_prop_len, NULL, 0);
     sysctl(d_prop, 2, device, &d_prop_len, NULL, 0);
-    
+
     int version_prop[2] = {CTL_KERN, KERN_OSVERSION};
     char version[20];
     size_t version_prop_len = sizeof(version);
     //sysctl(version_prop, 2, NULL, &version_prop_len, NULL, 0);
     sysctl(version_prop, 2, version, &version_prop_len, NULL, 0);
-    
-    
+
+    /******ADD IPADS HERE*****/
+
+    /*****ADD 32 bit DEVICES HERE****/
+
+    //iPhone 5s
+    if(!strcmp(device, "iPhone6,2") || !strcmp(device, "iPhone6,1"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+    		OFFSET_REALHOST                             = 0xfffffff00752eba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff007081dc0;
+    		OFFSET_COPYIN                               = 0xfffffff007180e98;
+    		OFFSET_COPYOUT                              = 0xfffffff00718108c;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006522174;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+    		OFFSET_REALHOST                             = 0xfffffff00752eba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff007081dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071811ec;
+    		OFFSET_COPYOUT                              = 0xfffffff0071813e0;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f14;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1ec;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a38;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006526174;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff00754c478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075a8050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075a8048;
+    		OFFSET_REALHOST                             = 0xfffffff00752eba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff007081dc0;
+    		OFFSET_COPYIN                               = 0xfffffff007181218;
+    		OFFSET_COPYOUT                              = 0xfffffff00718140c;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099f7c;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad1d4;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099aa0;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006f25538;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006525174;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone 6+
+    if(!strcmp(device, "iPhone7,1"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		LOG("10.3.3 - 14G60 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		LOG("10.3.2 - 14F89 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		LOG("10.3.1 - 14E304 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone 6
+    if(!strcmp(device, "iPhone7,2"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+    		OFFSET_REALHOST                             = 0xfffffff00753aba0;
+    		OFFSET_BZERO                                = 0xfffffff00708df80;
+    		OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+    		OFFSET_COPYIN                               = 0xfffffff00718d028;
+    		OFFSET_COPYOUT                              = 0xfffffff00718d21c;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a60b4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b938c;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5bd8;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006135000 + 0x1030;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b2174;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+    		OFFSET_REALHOST                             = 0xfffffff00753aba0;
+    		OFFSET_BZERO                                = 0xfffffff00708df80;
+    		OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+    		OFFSET_COPYIN                               = 0xfffffff00718d37c;
+    		OFFSET_COPYOUT                              = 0xfffffff00718d570;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a60b4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b938c;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5bd8;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eee1b8;
+    		//OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b2174;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006642c90;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+    		OFFSET_REALHOST                             = 0xfffffff00753aba0;
+    		OFFSET_BZERO                                = 0xfffffff00708df80;
+    		OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+    		OFFSET_COPYIN                               = 0xfffffff00718d3a8;
+    		OFFSET_COPYOUT                              = 0xfffffff00718d59c;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a611c;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b9374;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5c40;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eed2b8;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b5174;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone 6s
+    if(!strcmp(device, "iPhone8,1"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
+    		OFFSET_REALHOST                             = 0xfffffff00752aba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff007081dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071803a0;
+    		OFFSET_COPYOUT                              = 0xfffffff007180594;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e7c9f8;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006462174;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
+    		OFFSET_REALHOST                             = 0xfffffff00752aba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff007081dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071806f4;
+    		OFFSET_COPYOUT                              = 0xfffffff0071808e8;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e7c9f8;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b1398;
+        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+    		OFFSET_REALHOST                             = 0xfffffff00753aba0;
+    		OFFSET_BZERO                                = 0xfffffff00708df80;
+    		OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+    		OFFSET_COPYIN                               = 0xfffffff00718d3a8;
+    		OFFSET_COPYOUT                              = 0xfffffff00718d59c;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a611c;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b9374;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5c40;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006eee1b8;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064b5174;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone 6s+
+    if(!strcmp(device, "iPhone8,2"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		LOG("10.3.3 - 14G60 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		LOG("10.3.2 - 14F89 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		LOG("10.3.1 - 14E304 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone SE
+    if(!strcmp(device, "iPhone8,4"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		LOG("10.3.3 - 14G60 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff007081dc0;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0071806f4;
+    		OFFSET_REALHOST                             = 0xfffffff00752aba0;
+    		OFFSET_BZERO                                = 0xfffffff007081f80;
+    		OFFSET_BCOPY                                = 0xfffffff0071808e8;
+    		OFFSET_COPYIN                               = 0xfffffff0075a4050;
+    		OFFSET_COPYOUT                              = 0xfffffff0075a4048;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099e94;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad16c;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070999b8;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e849f8;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006482174;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+        OFFSET_ZONE_MAP                             = 0xfffffff007548478;
+        OFFSET_KERNEL_MAP                           = 0xfffffff0075a4050;
+        OFFSET_KERNEL_TASK                          = 0xfffffff0075a4048;
+        OFFSET_REALHOST                             = 0xfffffff00752aba0;
+        OFFSET_BZERO                                = 0xfffffff007081f80;
+        OFFSET_BCOPY                                = 0xfffffff007081dc0;
+        OFFSET_COPYIN                               = 0xfffffff007180720;
+        OFFSET_COPYOUT                              = 0xfffffff007180914;
+        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff007099efc;
+        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070ad154;
+        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff007099a20;
+        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e83af8;
+        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff006481174;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPhone 7
+    if(!strcmp(device, "iPhone9,3") || !strcmp(device, "iPhone9,1"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+    		OFFSET_REALHOST                             = 0xfffffff007572ba0;
+    		OFFSET_BZERO                                = 0xfffffff0070c1f80;
+    		OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071c5db4;
+    		OFFSET_COPYOUT                              = 0xfffffff0071c6094;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+    		// OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c5398;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fb0a8;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+    		OFFSET_REALHOST                             = 0xfffffff007572ba0;
+    		OFFSET_BZERO                                = 0xfffffff0070c1f80;
+    		OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071c6108;
+    		OFFSET_COPYOUT                              = 0xfffffff0071c63e8;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0065000a8;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+        OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+        OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+        OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+        OFFSET_REALHOST                             = 0xfffffff007572ba0;
+        OFFSET_BZERO                                = 0xfffffff0070c1f80;
+        OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+        OFFSET_COPYIN                               = 0xfffffff0071c6134;
+        OFFSET_COPYOUT                              = 0xfffffff0071c6414;
+        OFFSET_CHGPROCCNT                           = 0xfffffff007049e4b;
+        OFFSET_KAUTH_CRED_REF                       = 0xfffffff0073ada04;
+        OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070df05c;
+        OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22b4;
+        OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb80;
+        OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e4a238;
+        OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064ff0a8;
+        OFFSET_ROP_LDR_X0_X0_0x10                   = 0xfffffff0074cf02c;
+        OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    }
+
+    //iPhone 7 Plus
+    if(!strcmp(device, "iPhone9,4") || !strcmp(device, "iPhone9,2"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+    		OFFSET_REALHOST                             = 0xfffffff007572ba0;
+    		OFFSET_BZERO                                = 0xfffffff0070c1f80;
+    		OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071c5db4;
+    		OFFSET_COPYOUT                              = 0xfffffff0071c6094;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+    		// OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c5398;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064fb0a8;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+    		OFFSET_REALHOST                             = 0xfffffff007572ba0;
+    		OFFSET_BZERO                                = 0xfffffff0070c1f80;
+    		OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071c6108;
+    		OFFSET_COPYOUT                              = 0xfffffff0071c63e8;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070deff4;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22cc;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb18;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+    		// OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063ca398;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0065000a8;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		OFFSET_ZONE_MAP                             = 0xfffffff007590478;
+    		OFFSET_KERNEL_MAP                           = 0xfffffff0075ec050;
+    		OFFSET_KERNEL_TASK                          = 0xfffffff0075ec048;
+    		OFFSET_REALHOST                             = 0xfffffff007572ba0;
+    		OFFSET_BZERO                                = 0xfffffff0070c1f80;
+    		OFFSET_BCOPY                                = 0xfffffff0070c1dc0;
+    		OFFSET_COPYIN                               = 0xfffffff0071c6134;
+    		OFFSET_COPYOUT                              = 0xfffffff0071c6414;
+    		OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070df05c;
+    		OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070f22b4;
+    		OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070deb80;
+    		OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006e49208 + 0x1030;
+    		// OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0063c9398;
+    		OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff0064ff0a8;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+    //iPod touch 6
+    if(!strcmp(device, "iPod7,1"))
+    {
+     	//10.3.3
+    	if(!strcmp(version, "14G60"))
+    	{
+    		LOG("10.3.3 - 14G60 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.2
+    	if(!strcmp(version, "14F89"))
+    	{
+    		LOG("10.3.2 - 14F89 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3.1
+    	if(!strcmp(version, "14E304"))
+    	{
+    		LOG("10.3.1 - 14E304 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+    	//10.3
+    	if(!strcmp(version, "14E277"))
+    	{
+    		LOG("10.3 - 14E277 offsets not found for %s", device);
+    		return -1;;
+    	}
+
+
+    }
+
+
     if (!strcmp(device, "iPhone9,3"))
     {
         if (!strcmp(version, "14E304"))
@@ -74,7 +580,7 @@ int init_symbols()
             OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
         }
     }
-    
+
     else if (!strcmp(device, "iPhone8,1"))
     {
         if (!strcmp(version, "14F89"))
@@ -95,7 +601,7 @@ int init_symbols()
             OFFSET_ROOT_MOUNT_V_NODE                    = 0xfffffff0075ec0b0;
         }
     }
-    
+
     else
     {
         LOG("Device not supported.");
@@ -106,4 +612,3 @@ int init_symbols()
     LOG("test offset addx0x0x10gadget: %llx", OFFSET_ROP_ADD_X0_X0_0x10);
     return 0;
 }
-

--- a/v0rtex-S/symbols.m
+++ b/v0rtex-S/symbols.m
@@ -50,6 +50,20 @@ int init_symbols()
     //sysctl(version_prop, 2, NULL, &version_prop_len, NULL, 0);
     sysctl(version_prop, 2, version, &version_prop_len, NULL, 0);
 
+
+    /******READ BEFORE ADDING OFFSETS********/
+    /*
+    certain models have the same kernelcache. For example, iPhone6,1 and iPhone6,2 (iPhone 5s GSM and global)
+    they both have the same ipsw and same kernelcache. Such models should be combined with an OR logic
+    check how iPhone 7 and 5s models are combined
+    This file has conditions for all devices that have 10.3 or above, including 32 bit ones
+    but I haven't combined all devices like I mentioned above. If you're adding offsets for such a device, check the BuildManifest or the sha1 hash of ipsw files, and combine such devices with an OR logic.
+    Hardware platform (xxUAP and xxAP etc) doesn't matter, since kernel is the same. Just be careful when you get the kernelcache from the firmware package. Pick the right one. check BuildManifest if necessary
+    Thanks to everyone who worked hard for this.
+    */
+
+
+
     /******ADD IPADS HERE*****/
 
     /*****ADD 32 bit DEVICES HERE****/

--- a/v0rtex-s.xcodeproj/project.pbxproj
+++ b/v0rtex-s.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		81BE350D1FEBC83100525F57 /* nvpatch.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BE35091FEBC83100525F57 /* nvpatch.m */; };
 		B544A5C61FEB2F3400AA5749 /* bootstrap.tar in Resources */ = {isa = PBXBuildFile; fileRef = B544A5C51FEB2F3400AA5749 /* bootstrap.tar */; };
 		B58B32401FE4EBA300EB7B47 /* kernel.m in Sources */ = {isa = PBXBuildFile; fileRef = B58B323D1FE4EBA300EB7B47 /* kernel.m */; };
 		B58B32461FE4ED6300EB7B47 /* symbols.m in Sources */ = {isa = PBXBuildFile; fileRef = B58B32451FE4ED6300EB7B47 /* symbols.m */; };
@@ -31,6 +32,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		81BE35091FEBC83100525F57 /* nvpatch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = nvpatch.m; sourceTree = "<group>"; };
+		81BE350A1FEBC83100525F57 /* nvpatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nvpatch.h; sourceTree = "<group>"; };
+		81BE350B1FEBC83100525F57 /* arch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = arch.h; sourceTree = "<group>"; };
+		81BE350C1FEBC83100525F57 /* mach-o.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "mach-o.h"; sourceTree = "<group>"; };
 		B544A5C51FEB2F3400AA5749 /* bootstrap.tar */ = {isa = PBXFileReference; lastKnownFileType = archive.tar; path = bootstrap.tar; sourceTree = "<group>"; };
 		B58B323D1FE4EBA300EB7B47 /* kernel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = kernel.m; sourceTree = "<group>"; };
 		B58B323F1FE4EBA300EB7B47 /* kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel.h; sourceTree = "<group>"; };
@@ -113,6 +118,10 @@
 				EE5252AF1FDA4F2F00993801 /* ViewController.h */,
 				EE5252B01FDA4F2F00993801 /* ViewController.m */,
 				EE5169291FDC2C9D00805460 /* common.h */,
+				81BE350B1FEBC83100525F57 /* arch.h */,
+				81BE350C1FEBC83100525F57 /* mach-o.h */,
+				81BE350A1FEBC83100525F57 /* nvpatch.h */,
+				81BE35091FEBC83100525F57 /* nvpatch.m */,
 				EE81AD151FDEF1AB0094418B /* v0rtex.h */,
 				EE5169271FDC2A7000805460 /* v0rtex.m */,
 				B58B323F1FE4EBA300EB7B47 /* kernel.h */,
@@ -236,6 +245,7 @@
 				EE5252B11FDA4F2F00993801 /* ViewController.m in Sources */,
 				EE5252BC1FDA4F2F00993801 /* main.m in Sources */,
 				EE5252AE1FDA4F2F00993801 /* AppDelegate.m in Sources */,
+				81BE350D1FEBC83100525F57 /* nvpatch.m in Sources */,
 				EE5169281FDC2A7000805460 /* v0rtex.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -375,7 +385,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6EKJWC698P;
+				DEVELOPMENT_TEAM = WATF666TG9;
 				ENABLE_BITCODE = NO;
 				GCC_NO_COMMON_BLOCKS = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/v0rtex-S/Info.plist";
@@ -385,7 +395,7 @@
 					"$(PROJECT_DIR)/v0rtex-S",
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sticktron.v0rtex;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xninja.v0rtex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -400,7 +410,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6EKJWC698P;
+				DEVELOPMENT_TEAM = WATF666TG9;
 				ENABLE_BITCODE = NO;
 				GCC_NO_COMMON_BLOCKS = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/v0rtex-S/Info.plist";
@@ -410,7 +420,7 @@
 					"$(PROJECT_DIR)/v0rtex-S",
 				);
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sticktron.v0rtex;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xninja.v0rtex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
**pls read, senpai**

- changes the button to say 'go', since we're not just running the sploit anymore
- use sysctl calls to get hw identifier and current build id
- organized device, build id blocks to add offset for every possible device that has 10.3 - 10.3.3(more will be added in the next commit)
- log test offset, device identifier, build id, kern version to console so that you can actually check if it loads the offset 
- fixed a condition check in offset loading
- changed some return values and comparisons to match C standards 
- removed comparisons using Foundation objects for identifying device + buildid combinations (replaced with C string for consistency. We're now using NSObjects only in viewController stuff)

Patches the nvram variable 'com.apple.System.boot-nonce' to enable users to set generator.
note : this has to be done as part of the exploit as we have both kernel task and kernel base address. Getting these in a different tool is not that easy. Requires getting tfp0 and kernel base address. We will be compelled to do this in future. 

